### PR TITLE
major refactor to avoid code repetition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you need unique identifiers in your Node.js app for use in a database such as
 
 - uniform - all ids are 32 characters long.
 - unique - no two ids will be the same, or at least the likelihood of a clash is vanishingly small.
-- time-sortable - the ids sort into time order, with one second precision.
+- time-sortable - the ids sort into time order (or reverse time order), with one second (or millisecond) precision.
 
 If a `kuuid`-generated id were used as a database's unique identifier, it would sort roughly in time order (`kuuid.id()`), or reverse time order (`kuuid.idr()`)
 
@@ -46,7 +46,25 @@ let doc = {
 db.insert(doc)
 ```
 
-Supplying no parameter to `kuuid.id()` uses the current time to generate the timestamp part of the id. You may also supply your own date/time:
+## Parameters
+
+By default, the `id()` function returns an id made up of a timestamp derived from "now" to second precision, 128 bits of data and it will sort in oldest-first order. This can be configured by overriding these defaults:
+
+```js
+const id = kuuid.id({
+  timestamp: '2000-01-01T10:24:22.000Z', // use a known timestamp
+  random: 1, // use less random data
+  reverse: true, // sort in newest first order
+  millisecond: true // the timestamp should be to millisecond precision
+})
+```
+
+- `timestamp` - an ISO string representing the date/time required or an integer representing the number of milliseconds since 1970. Default "now"
+- `random` - the quantity of random data. Between 1 and 4. Default `4`.
+- `reverse` - if true, the id will sort in newest-first order. Default `false`.
+- `millisecond` - if true, the id's time component will be stored with milliecond precision. Default `false`.
+
+For backwards compatibility, the `id()` function will also accept a string or number parameter representing the timestamp.
 
 ```js
 // 'now'
@@ -59,89 +77,24 @@ kuuid.id('2018-07-20T10:10:34.234Z')
 kuuid.id(1514764800000)
 ```
 
-## Reverse mode
+## Shortcut functions
 
-If you want your data to sort into "newest first" order, then `kuuid.idr()` returns an id that sorts in the opposite order:
-
-```js
-// 'now'
-kuuid.idr()
-// zzyIy6DZ2SKTqh2WpV6D0DTbkK0kbn5u
-
-// Epoch
-kuuid.idr('1970-01-01T00:00:00Z')
-// zzzzzzzz2v3VKT4Sl9yV2f6v673SDt5v
-```
-
-## Millisecond mode
-
-If you want your ids to have millsecond prevision then use `idms()`:
-
-```js
-// 'now'
-kuuid.idms()
-// 0T6vppV82RX4Nx1ZzGqB0Exjjs4fkuhh
-```
-
-```js
-// 'now' reverse
-kuuid.idmsr()
-// zWt4A9Wz3TxK0h4MRkec06xADk3kIemn
-```
-
-## Short ids
-
-If you want your ids shorter (timestamp + 64 bits of random data ), then use `ids()` & `idsr()` for forward and reverse, respectively:
-
-```js
-// forward
-kuuid.ids()
-// 0S9QEzP23Wyk3p4IfNi6
-
-// reverse
-kuuid.idsr()
-// zzyFmalU06RfUZ3zMoay
-```
-
-## Generating a prefix
-
-If you only need the time-based prefix, you can call `kuuid.prefix()`:
-
-```js
-// 'now'
-kuuid.prefix()
-
-// ISO String 
-kuuid.prefix('2018-07-20T10:10:34.234Z')
-
-// millseconds since 1970
-kuuid.prefix(1514764800000)
-```
-
-or for a reverse-mode prefix:
-
-```js
-kuuid.prefixReverse()
-```
-
-or for a millisecond-precision version:
-
-```js
-kuuid.prefixms()
-```
-
-or for a millisecond-precision reversed version:
-
-```js
-kuuid.prefixReverseMs()
-```
+- `idr()` - returns an id that sorts in newest-first order.
+- `idms()` - returns an id with millisecond precision.
+- `ids()` - returns a shorter id (64-bits of random data).
+- `idsr()` - returns a short it in newest-first order.
+- `prefix()` - returns only the time prefix.
+- `prefixReverse()` - returns only the time prefix (reverse order).
+- `prefixms()` - returns only the time prefix with ms precision.
+- `prefixReverseMs()` - returns only the time prefix with ms precision. (reverse order).
+- `rand()` - returns the random portion of the id.
 
 ## How does it work?
 
 A `kuuid.id()` string has two parts:
 
 - 8 characters representing the number of seconds since 1st January 1970.
-- 24 characters containing random data.
+- 24 characters containing random data (for the default 128-bits)
 
 The front eight characters allow the string to be sorted by time. Two ids created in the same second will have the same front eight characters. The remaining 24 characters contain 128 bits of random data.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,26 +6,46 @@
 // TypeScript Version: 2.3
 
 declare namespace kuuid {
+
+  interface IDOpts {
+    /** The timestamp used to generate the id. Either an ISO string or number of milliseconds
+     * since 1970. Default: undefined, which 
+     */
+    timestamp?: string | number | undefined;
+    /** The amount of random data to append to the time portion of the id. A number
+     * between 1 and 4. Default: 4.
+     */
+    random?: number;
+    /** Whether to generate the id in oldest-first order (false) or newest-first order (true).
+     * Default: false
+     */
+    reverse?: boolean;
+    /** Whether to generate the id to second precision (false) or millisecond precision (true).
+     * Default: false
+     */
+    millsecond?: false;
+  }
+
   /**
    * Generate the 8-character prefix
    * @param t ISO-8601 date string or number of milliseconds since 1970
    * @return 8-character prefix string
    */
-  function prefix(t? : string | number): string;
+  function prefix(opts?: IDOpts | string | number): string;
 
   /**
    * Generate the 8-character prefix - reverse mode
    * @param t ISO-8601 date string or number of milliseconds since 1970
    * @return 8-character prefix string
    */
-  function prefixr(t? : string | number): string;
+  function prefixr(t?: string | number): string;
 
-    /**
-   * Generate the 8-character prefix - ms mode
-   * @param t ISO-8601 date string or number of milliseconds since 1970
-   * @return 8-character prefix string
-   */
-  function prefixms(t? : string | number): string;
+  /**
+ * Generate the 8-character prefix - ms mode
+ * @param t ISO-8601 date string or number of milliseconds since 1970
+ * @return 8-character prefix string
+ */
+  function prefixms(t?: string | number): string;
 
   /**
    * Generate 128-bits of random date encoded as 24 character string
@@ -35,38 +55,38 @@ declare namespace kuuid {
 
   /**
    * Generate a date/time sortable 32 character unique identifier
-   * @param t ISO-8601 date string or number of milliseconds since 1970
+   * @param t ISO-8601 date string or number of milliseconds since 1970 or options
    * @return 32-character id
    */
-  function id(t? : string | number): string;
+  function id(opts?: IDOpts | string | number): string;
 
   /**
    * Generate a reverse date/time sortable 32 character unique identifier
    * @param t ISO-8601 date string or number of milliseconds since 1970
    * @return 32-character id
    */
-  function idr(t? : string | number): string;
+  function idr(t?: string | number): string;
 
-    /**
-   * Generate short a date/time sortable 32 character unique identifier
-   * @param t ISO-8601 date string or number of milliseconds since 1970
-   * @return 32-character id
-   */
-  function ids(t? : string | number): string;
+  /**
+ * Generate short a date/time sortable 32 character unique identifier
+ * @param t ISO-8601 date string or number of milliseconds since 1970
+ * @return 32-character id
+ */
+  function ids(t?: string | number): string;
 
   /**
    * Generate short a reverse date/time sortable 32 character unique identifier
    * @param t ISO-8601 date string or number of milliseconds since 1970
    * @return 32-character id
    */
-  function idsr(t? : string | number): string;
+  function idsr(t?: string | number): string;
 
-    /**
-   * Generate a millisecond, time sortable 32 character unique identifier
-   * @param t ISO-8601 date string or number of milliseconds since 1970
-   * @return 32-character id
-   */
-  function idms(t? : string | number): string;
+  /**
+ * Generate a millisecond, time sortable 32 character unique identifier
+ * @param t ISO-8601 date string or number of milliseconds since 1970
+ * @return 32-character id
+ */
+  function idms(t?: string | number): string;
 }
 
 export = kuuid

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuuid",
-  "version": "0.6.2",
+  "version": "1.0.1",
   "description": "K-sortable UUID - roughly time-sortable unique id generator",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- allow `.id()` to accept options object instead of just a timestamp
- make all the other functions into shortcut functions - they may go away in the future because you can do everything with `.id`
