### PR TITLE
fix typescript types for `millisecond` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare namespace kuuid {
     /** Whether to generate the id to second precision (false) or millisecond precision (true).
      * Default: false
      */
-    millsecond?: false;
+    millisecond?: boolean;
   }
 
   /**


### PR DESCRIPTION
The TypeScript type for option `millisecond` was `false`, and it prevents assigning `true` to this option. Moreover, the name of the variable is typed wrongly as `millsecond`.

This PR fixes these problems. Thanks in advance.

